### PR TITLE
Fixed filename capitalisation that was BREAKING composer.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     
     "autoload": {
         "classmap": [
-            "src/parser.php"
+            "src/Parser.php"
         ]
     }
 }


### PR DESCRIPTION
Composer was failing during autoload file generation as the json pointed to `parser.php` instead of `Parser.php`. My guess is that it worked correctly on case-inensitive system, but it was definitely broken on Linux.